### PR TITLE
Disable Performance/ChainArrayAllocation

### DIFF
--- a/.rubocop.ruby.yml
+++ b/.rubocop.ruby.yml
@@ -365,7 +365,7 @@ Performance/RegexpMatch:
   Severity: refactor
 
 Performance/ChainArrayAllocation:
-  Severity: refactor
+  Enabled: false
 
 Performance/OpenStruct:
   Severity: refactor


### PR DESCRIPTION
It's advice is terrible, `uniq` and `uniq!` behave differently, `uniq!`
can't be chained because it returns nil when there are no duplicates.
Same goes with similar functions that this cop gives advice for.