### PR TITLE
Remove deprecated config option

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,14 @@
 require:
   - rubocop-performance
   - rubocop-rails
+  - rubocop-rspec
 
 # locally for testing purposes
 inherit_from:
   - config/ruby.yml
   - config/performance.yml
   - config/rails.yml
+  - config/rspec.yml
 
 AllCops:
   EnabledByDefault: true

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rubocop"
-gem "rubocop-performance"
-gem "rubocop-rails"
+gem "rubocop-performance", require: false
+gem "rubocop-rails",       require: false
+gem "rubocop-rspec",       require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,12 +4,12 @@ GEM
     ast (2.4.0)
     jaro_winkler (1.5.4)
     parallel (1.19.1)
-    parser (2.7.0.2)
+    parser (2.7.0.4)
       ast (~> 2.4.0)
     rack (2.2.2)
     rainbow (3.0.0)
     rexml (3.2.4)
-    rubocop (0.80.0)
+    rubocop (0.80.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
@@ -22,6 +22,8 @@ GEM
     rubocop-rails (2.4.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
+    rubocop-rspec (1.38.1)
+      rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     unicode-display_width (1.6.1)
 
@@ -29,9 +31,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  rubocop
   rubocop-performance
   rubocop-rails
+  rubocop-rspec
 
 BUNDLED WITH
    2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,24 +4,26 @@ GEM
     ast (2.4.0)
     jaro_winkler (1.5.4)
     parallel (1.19.1)
-    parser (2.6.5.0)
+    parser (2.7.0.2)
       ast (~> 2.4.0)
-    rack (2.0.8)
+    rack (2.2.2)
     rainbow (3.0.0)
-    rubocop (0.77.0)
+    rexml (3.2.4)
+    rubocop (0.80.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.6)
+      parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      rexml
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-performance (1.5.1)
+    rubocop-performance (1.5.2)
       rubocop (>= 0.71.0)
-    rubocop-rails (2.4.0)
+    rubocop-rails (2.4.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
     ruby-progressbar (1.10.1)
-    unicode-display_width (1.6.0)
+    unicode-display_width (1.6.1)
 
 PLATFORMS
   ruby
@@ -32,4 +34,4 @@ DEPENDENCIES
   rubocop-rails
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ Here's a common place to start for a Rails project:
 require:
   - rubocop-performance
   - rubocop-rails
+  - rubocop-rspec
 
 inherit_from:
-  - https://raw.githubusercontent.com/UseFedora/rubocop-config/master/config/ruby.yml
-  - https://raw.githubusercontent.com/UseFedora/rubocop-config/master/config/performance.yml
-  - https://raw.githubusercontent.com/UseFedora/rubocop-config/master/config/rails.yml
+  - https://config.teachablecdn.com/rubocop/ruby.yml
+  - https://config.teachablecdn.com/rubocop/performance.yml
+  - https://config.teachablecdn.com/rubocop/rails.yml
+  - https://config.teachablecdn.com/rubocop/rspec.yml
 
 AllCops:
   EnabledByDefault: true
@@ -44,10 +46,12 @@ And for non-rails projects:
 ``` yaml
 require:
   - rubocop-performance
+  - rubocop-rspec
 
 inherit_from:
-  - https://raw.githubusercontent.com/UseFedora/rubocop-config/master/config/ruby.yml
-  - https://raw.githubusercontent.com/UseFedora/rubocop-config/master/config/performance.yml
+  - https://config.teachablecdn.com/rubocop/ruby.yml
+  - https://config.teachablecdn.com/rubocop/performance.yml
+  - https://config.teachablecdn.com/rubocop/rspec.yml
 
 AllCops:
   EnabledByDefault: true
@@ -65,14 +69,15 @@ it. Add the `rubocop-performance` gem to your `Gemfile` to get it.
 ``` ruby
 group :development, :test do
   gem "rubocop-performance", require: false
-  gem "rubocop-rails", require: false
+  gem "rubocop-rails",       require: false
+  gem "rubocop-rspec",       require: false
 end
 ```
 
 We don't want to require it in normal use, just when running the rubocop command.
 
 And it should go without saying that `rubocop-rails` should only be added when
-you are in a Rails project.
+you are in a Rails project. The same goes for `rubocop-rspec`.
 
 ### `.gitignore`
 

--- a/bin/sync-config
+++ b/bin/sync-config
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euxo pipefail
+
+aws s3 sync --profile production --cache-control max-age=3600,public config/ s3://config.teachablecdn.com/rubocop

--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -1,0 +1,26 @@
+RSpec/MultipleExpectations:
+  Max: 16
+
+RSpec/ExampleLength:
+  Max: 50
+
+RSpec/MessageExpectation:
+  Enabled: false
+
+RSpec/DescribeClass:
+  Enabled: false
+
+RSpec/AlignLeftLetBrace:
+  Enabled: false
+
+RSpec/AlignRightLetBrace:
+  Enabled: false
+
+RSpec/InstanceVariable:
+  Enabled: false
+
+RSpec/Pending:
+  Enabled: false
+
+RSpec/DescribedClass:
+  Enabled: false

--- a/config/ruby.yml
+++ b/config/ruby.yml
@@ -46,9 +46,6 @@ Style/EmptyMethod:
 Style/Alias:
   EnforcedStyle: prefer_alias_method
 
-Style/BracesAroundHashParameters:
-  EnforcedStyle: context_dependent
-
 Style/WordArray:
   MinSize: 2
 

--- a/config/ruby.yml
+++ b/config/ruby.yml
@@ -203,6 +203,11 @@ Style/TrailingCommaInHashLiteral:
 Style/FloatDivision:
   Enabled: false
 
+Style/IpAddresses:
+  Exclude:
+    - "spec/**/*"
+    - "Gemfile"
+
 # Naming -----------------------------------------------------------------------
 
 Naming/PredicateName:


### PR DESCRIPTION
The config option that was removed is to facilitate migration to Ruby 3.

This should be merged in once most projects have upgrade to rubocop 0.80.0, and this can become main.